### PR TITLE
Added closing semicolon

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -95,4 +95,4 @@
   function checkPresence () {
     if (api.ready && !$main.contains($mainbar)) return destroy()
   }
-})()
+})();


### PR DESCRIPTION
Thanks for this very useful field !

Fixes an error thrown when the semicolon is missing at the end of the JS file and a script from another field is appended after. 

<img width="1176" alt="capture d ecran 2018-07-22 a 16 58 51" src="https://user-images.githubusercontent.com/14079751/43046980-0f40dece-8dd1-11e8-811b-a4b0a26b7225.png">
<img width="688" alt="capture d ecran 2018-07-22 a 16 59 28" src="https://user-images.githubusercontent.com/14079751/43046981-0f5823cc-8dd1-11e8-995b-e0f5973cd5f4.png">
